### PR TITLE
Fix pip dependency

### DIFF
--- a/project.json
+++ b/project.json
@@ -1,6 +1,6 @@
 {
   "dev-dependencies": [],
   "dependencies": [
-    "pip==9.0.1"
+    "pip>=18"
   ]
 }


### PR DESCRIPTION
Pinned requirements in a tool are bad, you deinstall my pip 18 for 9, and I certainly do not want that.